### PR TITLE
Fix score screen layout and responsive sizing

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "bun",
       "runtimeArgs": ["run", "dev", "--", "--host"],
-      "port": 5173
+      "port": 5174,
+      "autoPort": true
     }
   ]
 }

--- a/src/App.css
+++ b/src/App.css
@@ -426,40 +426,148 @@
 
 /* ── Intermediate Score ──────────────────────────────────── */
 
+.intermediate-score {
+    min-height: calc(100vh - var(--topbar-height));
+    width: 100%;
+    background: linear-gradient(160deg, #0d0d1a 0%, #111122 50%, #0a0a16 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    padding: 24px 16px;
+    color: #fff;
+    box-sizing: border-box;
+}
+
+.intermediate-score__round {
+    margin: 0;
+    font-size: clamp(0.9rem, 2.5vw, 1.1rem);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.45);
+}
+
 .intermediate-map-wrapper {
     position: relative;
+    flex-shrink: 0;
+}
+
+.intermediate-score__info {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.intermediate-score__distance {
+    margin: 0;
+    font-size: clamp(0.8rem, 2vw, 0.95rem);
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.intermediate-score__score {
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: #6ee7b7;
+}
+
+.intermediate-score__score-max {
+    font-size: 0.55em;
+    font-weight: 500;
+    color: rgba(110, 231, 183, 0.6);
+}
+
+.intermediate-score__btn {
+    padding: 13px 44px;
+    background: rgba(40, 145, 108, 0.9);
+    border: none;
+    border-radius: 14px;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    box-shadow: 0 8px 28px rgba(40, 145, 108, 0.35);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.intermediate-score__btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 36px rgba(40, 145, 108, 0.5);
+}
+
+@media (max-width: 480px) {
+    .intermediate-score {
+        gap: 14px;
+        padding: 16px 12px;
+    }
 }
 
 /* ── Final Score ─────────────────────────────────────────── */
 
 .final-score {
-    position: relative;
+    min-height: calc(100vh - var(--topbar-height));
     width: 100%;
-    height: 100%;
+    background: linear-gradient(160deg, #0d0d1a 0%, #111122 50%, #0a0a16 100%);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background-color: #282c34;
-    color: white;
+    gap: 12px;
+    color: #fff;
     user-select: none;
 }
 
+.final-score__title {
+    margin: 0 0 8px;
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: linear-gradient(135deg, #ffffff 30%, #a5b4fc 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
 .final-score__subtitle {
-    font-size: 24px;
+    margin: 0;
+    font-size: clamp(0.9rem, 2vw, 1rem);
+    color: rgba(255, 255, 255, 0.5);
 }
 
 .final-score__total {
-    font-size: 32px;
-    font-weight: bold;
+    margin: 0;
+    font-size: clamp(3rem, 10vw, 5rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: #6ee7b7;
+    line-height: 1;
+}
+
+.final-score__total-max {
+    margin: 0;
+    font-size: clamp(0.85rem, 2vw, 1rem);
+    color: rgba(255, 255, 255, 0.4);
 }
 
 .final-score__play-again {
-    padding: 10px 20px;
-    font-size: 18px;
-    margin-top: 20px;
+    margin-top: 16px;
+    padding: 13px 44px;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
     border: none;
-    border-radius: 5px;
-    background-color: #61dafb;
-    color: #282c34;
+    border-radius: 14px;
+    background: rgba(40, 145, 108, 0.9);
+    color: #fff;
+    box-shadow: 0 8px 28px rgba(40, 145, 108, 0.35);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.final-score__play-again:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 36px rgba(40, 145, 108, 0.5);
 }

--- a/src/screens/final-score/index.tsx
+++ b/src/screens/final-score/index.tsx
@@ -10,9 +10,10 @@ export function FinalScoreScreen({setState, gameData}:
 
     return (
         <div className="final-score">
-            <h1>Final Score</h1>
+            <h2 className="final-score__title">Final Score</h2>
             <p className="final-score__subtitle">Your total score is:</p>
-            <p className="final-score__total">{totalScore} out of a possible {gameData.totalRounds * 1000}</p>
+            <p className="final-score__total">{totalScore}</p>
+            <p className="final-score__total-max">out of a possible {gameData.totalRounds * 1000}</p>
             <button className="final-score__play-again" onClick={() => setState('landing')}>
                 Play Again
             </button>

--- a/src/screens/intermediate-score/index.tsx
+++ b/src/screens/intermediate-score/index.tsx
@@ -1,7 +1,6 @@
 import type {GameData, GameScreenName, MapLocation} from "../../types.ts";
 import MapDisplay from "../../components/map-display";
 import GuessLocation from "../../components/guess-location";
-import game from "../game";
 
 function IntermediateScore({setState, gameData, setGameData}:
                            {
@@ -28,30 +27,30 @@ function IntermediateScore({setState, gameData, setGameData}:
     const guessedLocation = gameData.guesses[gameData.currentRound];
     const distance = calculateDistance(location, guessedLocation);
     const score = Math.max(Math.round((1 - (distance / maxDistance)) * maxScore), 0);
-    const imageSize = window.innerWidth / 3;
+    // Responsive map size: large enough on mobile, capped on desktop
+    const imageSize = Math.min(window.innerWidth * 0.85, window.innerHeight * 0.55, 480);
+    const isLastRound = gameData.currentRound + 1 >= gameData.totalRounds;
+
     return (
-        <div>
-            <h1>Round {gameData.currentRound + 1}/{gameData.totalRounds}</h1>
+        <div className="intermediate-score">
+            <p className="intermediate-score__round">Round {gameData.currentRound + 1} / {gameData.totalRounds}</p>
             <div className="intermediate-map-wrapper">
                 <MapDisplay imageSize={imageSize} onClick={undefined} onMouseMove={undefined}/>
                 <GuessLocation actualLocation={location} guessLocation={guessedLocation} imageSize={imageSize}/>
             </div>
-
-            <p>Distance: {calculateDistance(location, guessedLocation).toFixed(2)} units</p>
-            <p>Score for this round: {score}/{maxScore}</p>
-            <button onClick={() => {
+            <div className="intermediate-score__info">
+                <p className="intermediate-score__distance">Distance: {distance.toFixed(0)} units</p>
+                <p className="intermediate-score__score">{score} <span className="intermediate-score__score-max">/ {maxScore}</span></p>
+            </div>
+            <button className="intermediate-score__btn" onClick={() => {
                 setGameData({
                     ...gameData,
                     scores: [...gameData.scores, score],
                     currentRound: gameData.currentRound + 1
                 });
-                if (gameData.currentRound + 1 >= gameData.totalRounds) {
-                    setState('final_scoring');
-                } else {
-
-                    setState('game');
-                }
-            }}>{gameData.currentRound + 1 >= gameData.totalRounds ? 'See Final Score' : 'Continue to Next Round'}
+                setState(isLastRound ? 'final_scoring' : 'game');
+            }}>
+                {isLastRound ? 'See Final Score' : 'Next Round'}
             </button>
         </div>
     );


### PR DESCRIPTION
## Summary

- **Intermediate score screen**: added a proper full-page dark-gradient wrapper, fixed the map size formula (`window.innerWidth / 3` → `min(85vw, 55vh, 480px)` — the old formula gave ~130px on a 390px mobile screen), replaced the oversized default `h1` with a styled round label, and added CSS classes for info text and the continue button
- **Final score screen**: fixed `height: 100%` → `min-height: calc(100vh - var(--topbar-height))` so flex centering actually works; replaced stale React-template colours (`#282c34` bg, `#61dafb` button) with the app's dark gradient + green palette; split the score number from "out of a possible X" into separate elements to prevent ugly text wrapping on mobile
- Both screens now match the existing app design language (dark gradient, teal score colour, green buttons)

## Test plan

- [ ] Play through a full 5-round game on desktop — intermediate score and final score screens render correctly centered with proper background
- [ ] Repeat on a mobile viewport (375px) — map fills the screen, no text wrapping on final score
- [ ] Click "Play Again" on final score — returns to landing screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)