### PR TITLE
Add mirror symmetry scoring and visualization

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,12 @@
     {
       "name": "dev",
       "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "dev", "--", "--host"],
-      "port": 5174,
+      "runtimeArgs": [
+        "run",
+        "dev",
+        "--host"
+      ],
+      "port": 5173,
       "autoPort": true
     }
   ]

--- a/src/App.css
+++ b/src/App.css
@@ -288,6 +288,38 @@
     line-height: 1.6;
 }
 
+.landing__settings {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 280px;
+}
+
+.landing__setting-label {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.65);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.landing__setting-value {
+    color: #6ee7b7;
+}
+
+.landing__slider {
+    width: 100%;
+    accent-color: #6ee7b7;
+}
+
+.landing__setting-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.3);
+    text-align: center;
+    line-height: 1.4;
+}
+
 .landing__start-btn {
     padding: 14px 48px;
     background: rgba(40, 145, 108, 0.9);
@@ -417,6 +449,14 @@
     background-color: red;
 }
 
+.pin--mirror {
+    background-color: cyan;
+    opacity: 0.85;
+    width: 10px;
+    height: 10px;
+    border: 1.5px solid rgba(255,255,255,0.5);
+}
+
 .pin-line {
     position: absolute;
     top: 0;
@@ -465,6 +505,11 @@
     margin: 0;
     font-size: clamp(0.8rem, 2vw, 0.95rem);
     color: rgba(255, 255, 255, 0.45);
+}
+
+.intermediate-score__mirror-tag {
+    color: cyan;
+    font-weight: 600;
 }
 
 .intermediate-score__score {

--- a/src/components/guess-location/index.tsx
+++ b/src/components/guess-location/index.tsx
@@ -1,35 +1,89 @@
-function GuessLocation({actualLocation, guessLocation, imageSize}) {
-    const mapSize = 10900 * 2;
-    // Convert actualLocation and guessLocation from map coordinates to [0,1] range
-    actualLocation = {
-        x: (actualLocation.x + mapSize / 2) / mapSize,
-        y: 1 - (actualLocation.y + mapSize / 2) / mapSize, // Invert Y axis
-    };
-    guessLocation = {
-        x: (guessLocation.x + mapSize / 2) / mapSize,
-        y: 1 - (guessLocation.y + mapSize / 2) / mapSize, // Invert Y axis
-    };
+import type {MapLocation} from "../../types.ts";
 
-    //draw a line between the two points using svg
+function toNormalized(loc: MapLocation) {
+    const mapSize = 10900 * 2;
+    return {
+        x: (loc.x + mapSize / 2) / mapSize,
+        y: 1 - (loc.y + mapSize / 2) / mapSize, // Invert Y axis
+    };
+}
+
+function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirror, imageSize}: {
+    actualLocation: MapLocation,
+    guessLocation: MapLocation,
+    mirrorLocation: MapLocation,
+    usedMirror: boolean,
+    imageSize: number,
+}) {
+    const actual = toNormalized(actualLocation);
+    const guess = toNormalized(guessLocation);
+    const mirror = toNormalized(mirrorLocation);
+
+    // Center of map in normalized coords (always 0.5, 0.5)
+    const center = { x: 0.5, y: 0.5 };
+
+    // Score line goes from guess to whichever location was used for scoring
+    const scoreTo = usedMirror ? mirror : actual;
+
     return (
         <>
-            <div
-                className="pin pin--actual"
-                style={{ left: `${actualLocation.x * 100}%`, top: `${actualLocation.y * 100}%` }}
-            />
-            <div
-                className="pin pin--guess"
-                style={{ left: `${guessLocation.x * 100}%`, top: `${guessLocation.y * 100}%` }}
-            />
+            {/* Mirror illustration: dashed line connecting actual ↔ mirror through the center */}
             <svg className="pin-line" width={imageSize} height={imageSize}>
+                {/* Axis line between actual and mirror, showing 180° rotational symmetry */}
                 <line
-                    x1={actualLocation.x * imageSize} y1={actualLocation.y * imageSize}
-                    x2={guessLocation.x * imageSize} y2={guessLocation.y * imageSize}
+                    x1={actual.x * imageSize} y1={actual.y * imageSize}
+                    x2={mirror.x * imageSize} y2={mirror.y * imageSize}
+                    stroke="rgba(255,255,255,0.25)"
+                    strokeWidth="1.5"
+                    strokeDasharray="4,4"
+                />
+                {/* Small center-of-rotation marker */}
+                <circle
+                    cx={center.x * imageSize} cy={center.y * imageSize}
+                    r="4"
+                    fill="none"
+                    stroke="rgba(255,255,255,0.35)"
+                    strokeWidth="1.5"
+                />
+                <line
+                    x1={center.x * imageSize - 6} y1={center.y * imageSize}
+                    x2={center.x * imageSize + 6} y2={center.y * imageSize}
+                    stroke="rgba(255,255,255,0.35)"
+                    strokeWidth="1.5"
+                />
+                <line
+                    x1={center.x * imageSize} y1={center.y * imageSize - 6}
+                    x2={center.x * imageSize} y2={center.y * imageSize + 6}
+                    stroke="rgba(255,255,255,0.35)"
+                    strokeWidth="1.5"
+                />
+                {/* Score line: guess → used target */}
+                <line
+                    x1={guess.x * imageSize} y1={guess.y * imageSize}
+                    x2={scoreTo.x * imageSize} y2={scoreTo.y * imageSize}
                     stroke="yellow"
                     strokeWidth="4"
                     strokeDasharray="5,2"
                 />
             </svg>
+
+            {/* Mirrored location pin */}
+            <div
+                className="pin pin--mirror"
+                style={{ left: `${mirror.x * 100}%`, top: `${mirror.y * 100}%` }}
+            />
+
+            {/* Actual location pin */}
+            <div
+                className="pin pin--actual"
+                style={{ left: `${actual.x * 100}%`, top: `${actual.y * 100}%` }}
+            />
+
+            {/* Guess pin */}
+            <div
+                className="pin pin--guess"
+                style={{ left: `${guess.x * 100}%`, top: `${guess.y * 100}%` }}
+            />
         </>
     );
 }

--- a/src/screens/intermediate-score/index.tsx
+++ b/src/screens/intermediate-score/index.tsx
@@ -21,12 +21,22 @@ function IntermediateScore({setState, gameData, setGameData}:
 
     const mapRadius = 10900;
     const maxScore = 1000;
-    const maxDistance = (mapRadius); // Maximum possible distance on the map
+    const maxDistance = mapRadius;
 
     const location = gameData.locations[gameData.currentRound].location;
     const guessedLocation = gameData.guesses[gameData.currentRound];
-    const distance = calculateDistance(location, guessedLocation);
-    const score = Math.max(Math.round((1 - (distance / maxDistance)) * maxScore), 0);
+    const mirroredLocation: MapLocation = { x: -location.x, y: -location.y };
+
+    const originalDistance = calculateDistance(location, guessedLocation);
+    const mirrorDistance = calculateDistance(mirroredLocation, guessedLocation);
+
+    const originalScore = Math.max(Math.round((1 - originalDistance / maxDistance) * maxScore), 0);
+    const mirrorScore = Math.max(Math.round((1 - mirrorDistance / maxDistance) * maxScore * gameData.mirrorMultiplier), 0);
+
+    const usedMirror = mirrorScore > originalScore;
+    const score = Math.max(originalScore, mirrorScore);
+    const effectiveDistance = usedMirror ? mirrorDistance : originalDistance;
+
     // Responsive map size: large enough on mobile, capped on desktop
     const imageSize = Math.min(window.innerWidth * 0.85, window.innerHeight * 0.55, 480);
     const isLastRound = gameData.currentRound + 1 >= gameData.totalRounds;
@@ -36,10 +46,19 @@ function IntermediateScore({setState, gameData, setGameData}:
             <p className="intermediate-score__round">Round {gameData.currentRound + 1} / {gameData.totalRounds}</p>
             <div className="intermediate-map-wrapper">
                 <MapDisplay imageSize={imageSize} onClick={undefined} onMouseMove={undefined}/>
-                <GuessLocation actualLocation={location} guessLocation={guessedLocation} imageSize={imageSize}/>
+                <GuessLocation
+                    actualLocation={location}
+                    guessLocation={guessedLocation}
+                    mirrorLocation={mirroredLocation}
+                    usedMirror={usedMirror}
+                    imageSize={imageSize}
+                />
             </div>
             <div className="intermediate-score__info">
-                <p className="intermediate-score__distance">Distance: {distance.toFixed(0)} units</p>
+                <p className="intermediate-score__distance">
+                    Distance: {effectiveDistance.toFixed(0)} units
+                    {usedMirror && <span className="intermediate-score__mirror-tag"> (mirror)</span>}
+                </p>
                 <p className="intermediate-score__score">{score} <span className="intermediate-score__score-max">/ {maxScore}</span></p>
             </div>
             <button className="intermediate-score__btn" onClick={() => {

--- a/src/screens/landing-screen/index.tsx
+++ b/src/screens/landing-screen/index.tsx
@@ -17,6 +17,7 @@ function LandingScreen({setState, setGameData, onExit}: {
                            onExit?: () => void,
                        }
 ) {
+    const [mirrorMultiplier, setMirrorMultiplier] = React.useState(1.0);
 
     const startLocations = locations.sort(() => 0.5 - random()).slice(0, rountCount);
 
@@ -29,6 +30,22 @@ function LandingScreen({setState, setGameData, onExit}: {
                 <p className="landing__subtitle">5 rounds — guess the location on the map</p>
             </div>
 
+            <div className="landing__settings">
+                <label className="landing__setting-label">
+                    Mirror credit: <span className="landing__setting-value">{Math.round(mirrorMultiplier * 100)}%</span>
+                </label>
+                <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.05"
+                    value={mirrorMultiplier}
+                    onChange={e => setMirrorMultiplier(parseFloat(e.target.value))}
+                    className="landing__slider"
+                />
+                <p className="landing__setting-hint">Score multiplier when your guess matches the mirrored location</p>
+            </div>
+
             <button
                 className="landing__start-btn"
                 onClick={() => {
@@ -38,7 +55,8 @@ function LandingScreen({setState, setGameData, onExit}: {
                         totalRounds: rountCount,
                         scores: [],
                         guesses: [],
-                        seed: seed
+                        seed: seed,
+                        mirrorMultiplier
                     });
                     setState('game');
                 }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,5 +19,6 @@ export type GameData = {
     totalRounds: number,
     scores: number[],
     guesses: MapLocation[],
-    seed: any
+    seed: any,
+    mirrorMultiplier: number
 }


### PR DESCRIPTION
## Summary
- Deadlock's map is mirrored 180° around the center, so Amber Hand locations have equivalents in Sapphire Flame territory. Scoring now takes the best of the direct distance vs. the mirrored distance.
- Configurable **Mirror credit** slider (0–100%) on the landing screen scales how much score a mirror match is worth.
- Intermediate score screen shows both the actual (white) and mirrored (cyan) pins, a dashed symmetry line through the center-of-rotation crosshair, and a yellow score line pointing to whichever target was used. A **(mirror)** tag appears on the distance readout when the mirror match scored higher.

## Test plan
- [ ] Launch game, verify mirror credit slider appears on landing screen and updates live
- [ ] Play a round and guess near the mirrored location of the answer — confirm score is credited and **(mirror)** tag appears
- [ ] Set mirror credit to 0%, guess the mirror — confirm no bonus is applied
- [ ] Verify cyan mirror pin and symmetry line render correctly on the intermediate score map
- [ ] Confirm existing (non-mirror) guesses score the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)