### PR TITLE
Add id-token: write permission to Claude issues workflow

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude:


### PR DESCRIPTION
Required by claude-code-action for OIDC token fetching even when using OAuth subscription token.

https://claude.ai/code/session_01WfRHVCESyq6xCND6vWw9hT