### PR TITLE
Fix auto-merge: decouple into separate PR trigger workflow

### DIFF
--- a/.github/workflows/auto-merge-dev-prs.yml
+++ b/.github/workflows/auto-merge-dev-prs.yml
@@ -1,0 +1,18 @@
+name: Auto-merge PRs targeting dev
+
+on:
+  pull_request:
+    branches: ['dev']
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -35,10 +35,3 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: dev
 
-      - name: Enable auto-merge on created PR
-        if: steps.claude.outputs.pull_request_number != ''
-        run: |
-          gh pr merge "${{ steps.claude.outputs.pull_request_number }}" \
-            --auto --squash --repo "${{ github.repository }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous approach relied on an undocumented output variable from claude-code-action. Instead, auto-merge is now handled by a dedicated workflow that fires on any PR opened against dev — more reliable and decoupled from the Claude workflow itself.

https://claude.ai/code/session_01WfRHVCESyq6xCND6vWw9hT