### PR TITLE
Show original and penalized scores when mirror location is used

### DIFF
--- a/src/games/location-guesser/definition.tsx
+++ b/src/games/location-guesser/definition.tsx
@@ -10,14 +10,12 @@ import {makeRandomSeed} from '../../utils/rng';
 import {getScoreEmoji} from '../../utils/scoring';
 
 const ROUND_COUNT = 5;
-const MIRROR_CREDIT = 0.5;
 const LG_DAILY_KEY = 'dailyChallenge_completed';
 
 export interface LGGameState extends BaseGameState {
     locations: LocationData[];
     guesses: MapLocation[];
     flips: boolean[];
-    mirrorMultiplier: number;
 }
 
 function LGLanding({onStart}: LandingProps) {
@@ -108,7 +106,6 @@ export const locationGuesserDefinition: GameDefinition<LGGameState> = {
             scores: [],
             currentRound: 0,
             totalRounds: count,
-            mirrorMultiplier: MIRROR_CREDIT,
             seed,
             isDaily,
             dailyDate: isDaily ? seed : undefined,

--- a/src/games/location-guesser/screens/Scoring.tsx
+++ b/src/games/location-guesser/screens/Scoring.tsx
@@ -16,10 +16,11 @@ function LGScoring({state, onContinue}: ScoringProps<LGGameState>) {
     const mirrorDistance = calculateDistance(mirroredLocation, guessedLocation);
 
     const originalScore = calculateTierScore(originalDistance);
-    const mirrorScore = Math.floor(calculateTierScore(mirrorDistance) * state.mirrorMultiplier);
+    const rawMirrorScore = calculateTierScore(mirrorDistance);
+    const mirrorScore = Math.max(rawMirrorScore - 2, 0);
 
-    const usedMirror = mirrorScore > originalScore;
-    const score = Math.max(originalScore, mirrorScore);
+    const usedMirror = rawMirrorScore > originalScore;
+    const score = usedMirror ? mirrorScore : originalScore;
     const effectiveDistance = usedMirror ? mirrorDistance : originalDistance;
 
     const scoreColor = SCORE_TIERS.find(t => t.score === score)?.color ?? '#9E9E9E';
@@ -150,9 +151,19 @@ function LGScoring({state, onContinue}: ScoringProps<LGGameState>) {
                     <p className="intermediate-score__distance">
                         Distance: {effectiveDistance.toFixed(0)} units
                     </p>
-                    <p className="intermediate-score__score" style={{color: scoreColor}}>
-                        {score} <span className="intermediate-score__score-max">/ 5</span>
-                    </p>
+                    {usedMirror ? (
+                        <p className="intermediate-score__score" style={{color: scoreColor}}>
+                            <span style={{textDecoration: 'line-through', opacity: 0.6, color: '#fff'}}>
+                                {rawMirrorScore}
+                            </span>
+                            {' → '}
+                            {score} <span className="intermediate-score__score-max">/ 5</span>
+                        </p>
+                    ) : (
+                        <p className="intermediate-score__score" style={{color: scoreColor}}>
+                            {score} <span className="intermediate-score__score-max">/ 5</span>
+                        </p>
+                    )}
                 </div>
                 <button className="intermediate-score__btn" onClick={() => onContinue(score)}>
                     {isLastRound ? 'See Final Score' : 'Next Round'}


### PR DESCRIPTION
When a mirrored location is used on the scoring screen, display both the raw mirror score (struck through) and the penalized score (raw - 2, min 0). Also updates the mirror penalty formula from ×0.5 to -2 and removes the now-unused mirrorMultiplier field.

Closes #14

Generated with [Claude Code](https://claude.ai/code)