### PR TITLE
feat: location guesser map UX improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -540,18 +540,18 @@
     position: relative;
     cursor: crosshair;
     transition: width 0.2s ease, height 0.2s ease;
+    overflow: hidden;
+    border-radius: 50%;
+    flex-shrink: 0;
 }
 
-.marker {
-    width: 10px;
-    height: 10px;
-    background-color: red;
-    border-radius: 50%;
+.marker-emoji {
     position: absolute;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -100%);
     pointer-events: none;
-    z-index: 1;
-    flex: 0 0 auto;
+    z-index: 2;
+    line-height: 1;
+    user-select: none;
 }
 
 .map-faction-label {
@@ -587,6 +587,29 @@
 
 /* ── Guess Location (pins + line) ────────────────────────── */
 
+.pin-emoji {
+    position: absolute;
+    transform: translate(-50%, -100%);
+    pointer-events: none;
+    z-index: 2;
+    line-height: 1;
+    user-select: none;
+}
+
+.pin-emoji--actual {
+    /* 📌 pushpin — no extra style needed */
+}
+
+.pin-emoji--guess {
+    /* 📍 map pin — no extra style needed */
+}
+
+.pin-emoji--mirror {
+    filter: hue-rotate(150deg) saturate(1.5);
+    opacity: 0.85;
+}
+
+/* Legacy dot pins used by Dead Reckoning */
 .pin {
     width: 5px;
     height: 5px;

--- a/src/components/guess-location/index.tsx
+++ b/src/components/guess-location/index.tsx
@@ -8,12 +8,13 @@ function toNormalized(loc: MapLocation) {
     };
 }
 
-function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirror, imageSize}: {
+function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirror, imageSize, zoom = 1}: {
     actualLocation: MapLocation,
     guessLocation: MapLocation,
     mirrorLocation: MapLocation,
     usedMirror: boolean,
     imageSize: number,
+    zoom?: number,
 }) {
     const actual = toNormalized(actualLocation);
     const guess = toNormalized(guessLocation);
@@ -21,6 +22,10 @@ function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirro
 
     // Score line goes from guess to whichever location was used for scoring
     const scoreTo = usedMirror ? mirror : actual;
+
+    // Counter-scale: keep visual size constant regardless of parent zoom
+    const strokeWidth = 2 / zoom;
+    const emojiSize = Math.round(24 / zoom);
 
     return (
         <>
@@ -33,28 +38,28 @@ function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirro
                             x1={actual.x * imageSize} y1={actual.y * imageSize}
                             x2={mirror.x * imageSize} y2={mirror.y * imageSize}
                             stroke="rgba(255,255,255,0.25)"
-                            strokeWidth="1.5"
-                            strokeDasharray="4,4"
+                            strokeWidth={strokeWidth}
+                            strokeDasharray={`${4 / zoom},${4 / zoom}`}
                         />
                         {/* Small center-of-rotation marker */}
                         <circle
                             cx={0.5 * imageSize} cy={0.5 * imageSize}
-                            r="4"
+                            r={4 / zoom}
                             fill="none"
                             stroke="rgba(255,255,255,0.35)"
-                            strokeWidth="1.5"
+                            strokeWidth={strokeWidth}
                         />
                         <line
-                            x1={0.5 * imageSize - 6} y1={0.5 * imageSize}
-                            x2={0.5 * imageSize + 6} y2={0.5 * imageSize}
+                            x1={0.5 * imageSize - 6 / zoom} y1={0.5 * imageSize}
+                            x2={0.5 * imageSize + 6 / zoom} y2={0.5 * imageSize}
                             stroke="rgba(255,255,255,0.35)"
-                            strokeWidth="1.5"
+                            strokeWidth={strokeWidth}
                         />
                         <line
-                            x1={0.5 * imageSize} y1={0.5 * imageSize - 6}
-                            x2={0.5 * imageSize} y2={0.5 * imageSize + 6}
+                            x1={0.5 * imageSize} y1={0.5 * imageSize - 6 / zoom}
+                            x2={0.5 * imageSize} y2={0.5 * imageSize + 6 / zoom}
                             stroke="rgba(255,255,255,0.35)"
-                            strokeWidth="1.5"
+                            strokeWidth={strokeWidth}
                         />
                     </>
                 )}
@@ -63,30 +68,36 @@ function GuessLocation({actualLocation, guessLocation, mirrorLocation, usedMirro
                     x1={guess.x * imageSize} y1={guess.y * imageSize}
                     x2={scoreTo.x * imageSize} y2={scoreTo.y * imageSize}
                     stroke="yellow"
-                    strokeWidth="2"
-                    strokeDasharray="2,0.5"
+                    strokeWidth={strokeWidth}
+                    strokeDasharray={`${2 / zoom},${0.5 / zoom}`}
                 />
             </svg>
 
             {/* Mirrored location pin — only shown when mirror was closer */}
             {usedMirror && (
                 <div
-                    className="pin pin--mirror"
-                    style={{left: `${mirror.x * 100}%`, top: `${mirror.y * 100}%`}}
-                />
+                    className="pin-emoji pin-emoji--mirror"
+                    style={{left: `${mirror.x * 100}%`, top: `${mirror.y * 100}%`, fontSize: emojiSize}}
+                >
+                    {'\uD83D\uDCCD' /* 📍 cyan tint via CSS filter */}
+                </div>
             )}
 
             {/* Actual location pin */}
             <div
-                className="pin pin--actual"
-                style={{left: `${actual.x * 100}%`, top: `${actual.y * 100}%`}}
-            />
+                className="pin-emoji pin-emoji--actual"
+                style={{left: `${actual.x * 100}%`, top: `${actual.y * 100}%`, fontSize: emojiSize}}
+            >
+                {'\uD83D\uDCCC' /* 📌 */}
+            </div>
 
             {/* Guess pin */}
             <div
-                className="pin pin--guess"
-                style={{left: `${guess.x * 100}%`, top: `${guess.y * 100}%`}}
-            />
+                className="pin-emoji pin-emoji--guess"
+                style={{left: `${guess.x * 100}%`, top: `${guess.y * 100}%`, fontSize: emojiSize}}
+            >
+                {'\uD83D\uDCCD' /* 📍 */}
+            </div>
         </>
     );
 }

--- a/src/components/map-selection/index.tsx
+++ b/src/components/map-selection/index.tsx
@@ -1,9 +1,33 @@
-//show map, with "Select location" button that becomes enabled when a location is selected
+// show map, with "Select location" button that becomes enabled when a location is selected
 
-import React, {useState, useRef} from "react";
+import React, {useState, useRef, useEffect, useCallback} from "react";
 import {flushSync} from "react-dom";
 import type {MapLocation} from "../../types.ts";
 import MapDisplay from "../map-display";
+
+const TOPBAR_HEIGHT = 52;
+const MAX_ZOOM = 4;
+
+function getMapCoordsRaw(clientX: number, clientY: number, rect: DOMRect, z: number, px: number, py: number, size: number, flipped: boolean) {
+    const cx = clientX - rect.left - size / 2;
+    const cy = clientY - rect.top - size / 2;
+    const contentCx = (cx - px) / z;
+    const contentCy = (cy - py) / z;
+    const rawX = contentCx / size + 0.5;
+    const rawY = contentCy / size + 0.5;
+    const x = flipped ? 1 - rawX : rawX;
+    const y = flipped ? 1 - rawY : rawY;
+    const dist = Math.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2);
+    return {x, y, dist};
+}
+
+function clampPan(px: number, py: number, z: number, size: number) {
+    const maxPan = (size * (z - 1)) / 2;
+    return {
+        x: Math.max(-maxPan, Math.min(maxPan, px)),
+        y: Math.max(-maxPan, Math.min(maxPan, py)),
+    };
+}
 
 function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped: boolean) => void }) {
     const [selectedLocation, setSelectedLocation] = useState<{ x: number, y: number } | null>(null);
@@ -11,27 +35,148 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
     const [fixedStyle, setFixedStyle] = useState<{ centerX: number, centerY: number, width: number, imageSize: number } | null>(null);
     const [isHovered, setIsHovered] = useState(false);
     const [isFlipped, setIsFlipped] = useState(false);
+    const [zoom, setZoom] = useState(1);
+    const [panX, setPanX] = useState(0);
+    const [panY, setPanY] = useState(0);
+
     const pendingLocationRef = useRef<MapLocation | null>(null);
     const transitionFiredRef = useRef(false);
     const divRef = useRef<HTMLDivElement>(null);
+    const mapDivRef = useRef<HTMLDivElement>(null);
+    const pinchStartRef = useRef<{ dist: number; zoom: number } | null>(null);
+
+    // Refs so event handlers always see current values without stale closures
+    const zoomRef = useRef(1);
+    const panRef = useRef({x: 0, y: 0});
+    const isFlippedRef = useRef(false);
+    const animPhaseRef = useRef<'idle' | 'fixed' | 'centering'>('idle');
+    const imageSizeRef = useRef(0);
+    const setLocationRef = useRef(setSelectedLocation);
+
+    zoomRef.current = zoom;
+    panRef.current = {x: panX, y: panY};
+    isFlippedRef.current = isFlipped;
+    animPhaseRef.current = animPhase;
+    setLocationRef.current = setSelectedLocation;
 
     const mapSize = 10900 * 2;
+    const maxMapSize = Math.min(window.innerWidth, window.innerHeight - TOPBAR_HEIGHT);
     const baseSize = Math.min(window.innerWidth * 0.45, 512);
-    const liveImageSize = isHovered ? Math.min(window.innerWidth * 0.85, 1024) : baseSize;
-    // Lock image size during animation so hover changes don't shift things mid-flight
+    const expandedSize = Math.min(maxMapSize * 0.90, 900);
+    const liveImageSize = isHovered ? expandedSize : baseSize;
     const imageSize = (animPhase !== 'idle' && fixedStyle) ? fixedStyle.imageSize : liveImageSize;
+    imageSizeRef.current = imageSize;
 
-    const handleMapClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-        if (animPhase !== 'idle') return;
-        const rect = event.currentTarget.getBoundingClientRect();
-        const rawX = (event.clientX - rect.left) / rect.width;
-        const rawY = (event.clientY - rect.top) / rect.height;
-        // When flipped 180°, invert both axes to get correct map coords
-        const x = isFlipped ? 1 - rawX : rawX;
-        const y = isFlipped ? 1 - rawY : rawY;
-        const dist = Math.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2);
+    const placePin = useCallback((clientX: number, clientY: number, rect: DOMRect) => {
+        const {x, y, dist} = getMapCoordsRaw(
+            clientX, clientY, rect,
+            zoomRef.current, panRef.current.x, panRef.current.y,
+            imageSizeRef.current, isFlippedRef.current
+        );
         if (dist > 0.5) return;
-        setSelectedLocation({x, y});
+        setLocationRef.current({x, y});
+    }, []);
+
+    // Non-passive wheel handler (must be attached via useEffect)
+    useEffect(() => {
+        const el = mapDivRef.current;
+        if (!el) return;
+
+        const handler = (e: WheelEvent) => {
+            e.preventDefault();
+            if (animPhaseRef.current !== 'idle') return;
+            const rect = el.getBoundingClientRect();
+            const size = imageSizeRef.current;
+            const cx = e.clientX - rect.left - size / 2;
+            const cy = e.clientY - rect.top - size / 2;
+            const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+            const oldZoom = zoomRef.current;
+            const newZoom = Math.max(1, Math.min(MAX_ZOOM, oldZoom * factor));
+            const oldPan = panRef.current;
+            const newPanX = cx - (cx - oldPan.x) * newZoom / oldZoom;
+            const newPanY = cy - (cy - oldPan.y) * newZoom / oldZoom;
+            const clamped = clampPan(newPanX, newPanY, newZoom, size);
+            zoomRef.current = newZoom;
+            panRef.current = {x: clamped.x, y: clamped.y};
+            setZoom(newZoom);
+            setPanX(clamped.x);
+            setPanY(clamped.y);
+        };
+
+        el.addEventListener('wheel', handler, {passive: false});
+        return () => el.removeEventListener('wheel', handler);
+    }, []);
+
+    // Non-passive touchmove handler (prevents page scroll while interacting with map)
+    useEffect(() => {
+        const el = mapDivRef.current;
+        if (!el) return;
+
+        const handler = (e: TouchEvent) => {
+            if (e.touches.length === 1 && animPhaseRef.current === 'idle') {
+                e.preventDefault();
+                const rect = el.getBoundingClientRect();
+                const {x, y, dist} = getMapCoordsRaw(
+                    e.touches[0].clientX, e.touches[0].clientY, rect,
+                    zoomRef.current, panRef.current.x, panRef.current.y,
+                    imageSizeRef.current, isFlippedRef.current
+                );
+                if (dist <= 0.5) setLocationRef.current({x, y});
+            } else if (e.touches.length === 2 && pinchStartRef.current) {
+                e.preventDefault();
+                const dx = e.touches[0].clientX - e.touches[1].clientX;
+                const dy = e.touches[0].clientY - e.touches[1].clientY;
+                const newDist = Math.sqrt(dx * dx + dy * dy);
+                const newZoom = Math.max(1, Math.min(MAX_ZOOM,
+                    pinchStartRef.current.zoom * newDist / pinchStartRef.current.dist
+                ));
+                const size = imageSizeRef.current;
+                const clamped = clampPan(panRef.current.x, panRef.current.y, newZoom, size);
+                zoomRef.current = newZoom;
+                panRef.current = clamped;
+                setZoom(newZoom);
+                setPanX(clamped.x);
+                setPanY(clamped.y);
+            }
+        };
+
+        el.addEventListener('touchmove', handler, {passive: false});
+        return () => el.removeEventListener('touchmove', handler);
+    }, [placePin]);
+
+    const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+        if (e.touches.length === 2) {
+            const dx = e.touches[0].clientX - e.touches[1].clientX;
+            const dy = e.touches[0].clientY - e.touches[1].clientY;
+            pinchStartRef.current = {dist: Math.sqrt(dx * dx + dy * dy), zoom};
+        }
+    };
+
+    const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+        pinchStartRef.current = null;
+        // Single tap (not a drag/pinch) places pin
+        if (e.changedTouches.length === 1 && e.touches.length === 0) {
+            const rect = e.currentTarget.getBoundingClientRect();
+            placePin(e.changedTouches[0].clientX, e.changedTouches[0].clientY, rect);
+        }
+    };
+
+    const handleMapClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (animPhase !== 'idle') return;
+        placePin(event.clientX, event.clientY, event.currentTarget.getBoundingClientRect());
+    };
+
+    const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (animPhase !== 'idle') return;
+        const rect = e.currentTarget.getBoundingClientRect();
+        // Check if cursor is inside the circular map image (unzoomed boundary)
+        const rawX = (e.clientX - rect.left) / rect.width;
+        const rawY = (e.clientY - rect.top) / rect.height;
+        const inCircle = Math.sqrt((rawX - 0.5) ** 2 + (rawY - 0.5) ** 2) <= 0.5;
+        setIsHovered(inCircle);
+        if (e.buttons === 1 && inCircle) {
+            placePin(e.clientX, e.clientY, rect);
+        }
     };
 
     const handleContinue = () => {
@@ -47,8 +192,6 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
         const rect = divRef.current!.getBoundingClientRect();
         const currentImageSize = liveImageSize;
 
-        // flushSync forces React to commit the 'fixed' state to the DOM synchronously,
-        // giving the browser a painted starting frame for the CSS transition.
         flushSync(() => {
             setFixedStyle({
                 centerX: rect.left + rect.width / 2,
@@ -60,7 +203,6 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
             setIsHovered(false);
         });
 
-        // Safety timeout: fires if rAF is suppressed (background/headless tab)
         const safetyId = setTimeout(() => {
             if (!transitionFiredRef.current) {
                 transitionFiredRef.current = true;
@@ -71,7 +213,6 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
         requestAnimationFrame(() => {
             clearTimeout(safetyId);
             setAnimPhase('centering');
-            // Fallback if transitionend never fires
             setTimeout(() => {
                 if (!transitionFiredRef.current) {
                     transitionFiredRef.current = true;
@@ -81,18 +222,17 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
         });
     };
 
-    const handleTransitionEnd = () => {
+    const handleTransitionEnd = (e: React.TransitionEvent) => {
+        // Only fire once — on the 'left' property which always changes
+        if (e.propertyName !== 'left') return;
         if (animPhase === 'centering' && !transitionFiredRef.current) {
             transitionFiredRef.current = true;
             onSubmit(pendingLocationRef.current!, isFlipped);
         }
     };
 
-    // On mobile, scale the map up to fill the viewport width during the centering animation.
     const isMobile = window.innerWidth <= 600;
-    const centeredScale = (isMobile && fixedStyle)
-        ? window.innerWidth / fixedStyle.width
-        : 1;
+    const centeredScale = (isMobile && fixedStyle) ? window.innerWidth / fixedStyle.width : 1;
 
     let dynamicStyle: React.CSSProperties = {};
     if (animPhase === 'fixed' && fixedStyle) {
@@ -125,53 +265,75 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
         };
     }
 
+    // Emoji counter-scale: keeps visual size constant regardless of zoom
+    const emojiSize = Math.round(24 / zoom);
+
     return (
         <div
             className="map-selection"
             ref={divRef}
             style={dynamicStyle}
             onTransitionEnd={handleTransitionEnd}
-            onMouseEnter={() => {
-                if (animPhase === 'idle') setIsHovered(true);
-            }}
             onMouseLeave={() => setIsHovered(false)}
         >
             <div
                 className="map"
+                ref={mapDivRef}
                 style={{
                     width: imageSize,
                     height: imageSize,
-                    transform: isFlipped ? 'rotate(180deg)' : undefined,
+                    overflow: 'hidden',
                 }}
+                onClick={handleMapClick}
+                onMouseMove={handleMouseMove}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
             >
-                <MapDisplay
-                    imageSize={imageSize}
-                    onClick={handleMapClick}
-                    onMouseMove={(e) => {
-                        if (e.buttons === 1) handleMapClick(e);
-                    }}
-                />
-                {selectedLocation && (
-                    <div
-                        className="marker"
-                        style={{
-                            left: `${selectedLocation.x * 100}%`,
-                            top: `${selectedLocation.y * 100}%`,
-                        }}
-                        title="Selected Location"
-                        draggable={false}
-                    />
-                )}
+                {/* Zoom + pan layer */}
+                <div style={{
+                    width: imageSize,
+                    height: imageSize,
+                    transform: `translate(${panX}px, ${panY}px) scale(${zoom})`,
+                    transformOrigin: 'center center',
+                    position: 'relative',
+                }}>
+                    {/* Flip layer */}
+                    <div style={{
+                        width: imageSize,
+                        height: imageSize,
+                        transform: isFlipped ? 'rotate(180deg)' : undefined,
+                        transformOrigin: 'center center',
+                        position: 'relative',
+                    }}>
+                        <MapDisplay
+                            imageSize={imageSize}
+                            onClick={undefined}
+                            onMouseMove={undefined}
+                        />
+                        {selectedLocation && (
+                            <div
+                                className="marker-emoji"
+                                style={{
+                                    left: `${selectedLocation.x * 100}%`,
+                                    top: `${selectedLocation.y * 100}%`,
+                                    fontSize: emojiSize,
+                                }}
+                                draggable={false}
+                            >
+                                {'\uD83D\uDCCD' /* 📍 */}
+                            </div>
+                        )}
 
-                <div
-                    className="map-faction-label map-faction-label--amber"
-                    style={isFlipped ? {transform: 'rotate(180deg)'} : undefined}
-                >The Hidden King</div>
-                <div
-                    className="map-faction-label map-faction-label--sapphire"
-                    style={isFlipped ? {transform: 'rotate(180deg)'} : undefined}
-                >The Archmother</div>
-
+                        <div
+                            className="map-faction-label map-faction-label--amber"
+                            style={isFlipped ? {transform: 'rotate(180deg)'} : undefined}
+                        >The Hidden King</div>
+                        <div
+                            className="map-faction-label map-faction-label--sapphire"
+                            style={isFlipped ? {transform: 'rotate(180deg)'} : undefined}
+                        >The Archmother</div>
+                    </div>
+                </div>
             </div>
             <div className="map-selection__controls" style={animPhase !== 'idle' ? {visibility: 'hidden'} : undefined}>
                 <button
@@ -180,7 +342,7 @@ function MapSelection({onSubmit}: { onSubmit: (location: MapLocation, isFlipped:
                     disabled={animPhase !== 'idle'}
                     title="View from opposing team's perspective"
                 >
-                    {isFlipped ? '↺ Normal' : '↺ Flip'}
+                    {isFlipped ? '\u21BA Normal' : '\u21BA Flip'}
                 </button>
                 <button
                     className="select-button"

--- a/src/games/location-guesser/screens/Scoring.tsx
+++ b/src/games/location-guesser/screens/Scoring.tsx
@@ -138,6 +138,7 @@ function LGScoring({state, onContinue}: ScoringProps<LGGameState>) {
                             mirrorLocation={mirroredLocation}
                             usedMirror={usedMirror}
                             imageSize={imageSize}
+                            zoom={zoom}
                         />
                         </div>
                     </div>


### PR DESCRIPTION
Implements all changes requested in issue #16:

- Map only enlarges when hovering over circular section
- Max size capped to min(viewport width, viewport height - topbar)
- Scroll/pinch zoom (1x–4x)
- Touch-and-drag moves guess pin on mobile
- 📍 emoji for guess, 📌 for correct location
- Pins and line maintain absolute scale when zoomed
- Fixed FLIP animation jump

Closes #16

Generated with [Claude Code](https://claude.ai/code)